### PR TITLE
Fix branch trigger for docs auto publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - master
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
The repo uses 'main' branch, and not 'master', thus GitHub action was not triggered.  :D